### PR TITLE
Enable the doxygen search-engine

### DIFF
--- a/doxygen-conf/doxygen.conf.in
+++ b/doxygen-conf/doxygen.conf.in
@@ -1085,7 +1085,7 @@ MATHJAX_RELPATH        = http://www.mathjax.org/mathjax
 # typically be disabled. For large projects the javascript based search engine
 # can be slow, then enabling SERVER_BASED_SEARCH may provide a better solution.
 
-SEARCHENGINE           = NO
+SEARCHENGINE           = YES
 
 # When the SERVER_BASED_SEARCH tag is enabled the search engine will be
 # implemented using a PHP enabled web server instead of at the web client


### PR DESCRIPTION
This PR enables the doxygen default search-engine to increase the experience of exploring the smtrat-api.

![doxygen-search](https://cloud.githubusercontent.com/assets/1412344/25774482/a6fc582c-328f-11e7-850d-217c1e324e1a.PNG)

